### PR TITLE
Tweaks for pushy/ruby-devel

### DIFF
--- a/recipes/floating_ip.rb
+++ b/recipes/floating_ip.rb
@@ -10,11 +10,6 @@ package 'gcc' do
   action :install
 end.run_action(:install)
 
-# Is this necessary? Or will just gcc work?
-package 'ruby-devel' do
-  action :install
-end.run_action(:install)
-
 # Behold the Nokogiri and tremble in fear!
 chef_gem 'nokogiri' do
   version '1.6.1'

--- a/recipes/secondary.rb
+++ b/recipes/secondary.rb
@@ -11,7 +11,6 @@ include_recipe 'aws_ha_chef::hosts'
 include_recipe 'aws_ha_chef::disable_iptables'
 include_recipe 'aws_ha_chef::server'
 include_recipe 'aws_ha_chef::ha'
-include_recipe 'aws_ha_chef::push_jobs'
 include_recipe 'aws_ha_chef::reporting'
 
 # Make sure we have LVM installed in case of failover


### PR DESCRIPTION
Installing ruby-devel on Centos just got 1.8.7 ruby-devel and  isn't needed.

Don't want pushy on Backend.